### PR TITLE
Upgrade co-body version from 4.2.0 to 5.1.1 fixing qs vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "https://github.com/adonisjs/adonis-middleware#readme",
   "dependencies": {
     "bytes": "^2.4.0",
-    "co-body": "^4.2.0",
+    "co-body": "^5.1.1",
     "csrf": "^3.0.4",
     "formidable": "^1.1.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Solve vulnerability in qs package

https://github.com/adonisjs/adonis-middleware/issues/11
 